### PR TITLE
Fix hard-coded paths

### DIFF
--- a/Scripts/NORLOT.2.Graphs.R
+++ b/Scripts/NORLOT.2.Graphs.R
@@ -1,4 +1,6 @@
-
+# Path configuration ------------------------------------------------------
+# Adjust directories if the repository layout changes
+data_dir <- "Data"
 
 # OLT.WT ------------------------------------------------------------------
 library(statsExpressions)
@@ -302,9 +304,9 @@ ggdraw()+
   draw_label("C", x = .01, y = .5, hjust = 0, vjust = 0, size = 15, fontface = "bold")+
   draw_label("D", x = .51, y = .5, hjust = 0, vjust = 0, size = 15, fontface = "bold")
 
-NORT.logo_file <- "C:/Users/germa/Lab Dropbox/Lab Neuroepigenetics/Lab of Neuroepigenetics/4. Huntington team - German Kevin/2-German - tesis/Analisis/GitHub/Thesis/Data/NORT.sqm.png"
-OLT.logo_file <- "C:/Users/germa/Lab Dropbox/Lab Neuroepigenetics/Lab of Neuroepigenetics/4. Huntington team - German Kevin/2-German - tesis/Analisis/GitHub/Thesis/Data/OLT.sqm.png"
-NORT.squema <- "C:/Users/germa/Lab Dropbox/Lab Neuroepigenetics/Lab of Neuroepigenetics/4. Huntington team - German Kevin/2-German - tesis/Analisis/GitHub/Thesis/Data/NORT.OLT.sqm.png"
+NORT.logo_file <- file.path(data_dir, "NORT.sqm.png")
+OLT.logo_file  <- file.path(data_dir, "OLT.sqm.png")
+NORT.squema    <- file.path(data_dir, "NORT.OLT.sqm.png")
 ggsave("graphs/NORTOLT.cmp.png", width = 15, height = 13, units = "cm", dpi = 300, bg=NULL)
 
 # anexos ------------------------------------------------------------------

--- a/Scripts/start.R
+++ b/Scripts/start.R
@@ -23,6 +23,10 @@ library("docxtools")
 library(weights)
 theme_update(plot.title = element_text(hjust = 0.5))
 
+# Path configuration ------------------------------------------------------
+# Adjust 'data_dir' if the repository structure changes
+data_dir <- "Data"
+
 # Opciones generales ------------------------------------------------------
 
 options(digits=3)
@@ -30,10 +34,10 @@ options(digits=3)
 
 # Data Loading ------------------------------------------------------------
 
-Main <- read_delim("C:/Users/germa/Lab Dropbox/Lab Neuroepigenetics/Lab of Neuroepigenetics/4. Huntington team - German Kevin/2-German - tesis/Analisis/GitHub/Thesis/Data/Main.csv", 
+Main <- read_delim(file.path(data_dir, "Main.csv"),
                    delim = ";", escape_double = FALSE, locale = locale(decimal_mark = ",", grouping_mark = "."), trim_ws = TRUE)
 
-RTqPCR.Data <- read_delim("C:/Users/germa/Lab Dropbox/Lab Neuroepigenetics/Lab of Neuroepigenetics/4. Huntington team - German Kevin/2-German - tesis/Analisis/GitHub/Thesis/Data/RTqPCR.Data.csv", 
+RTqPCR.Data <- read_delim(file.path(data_dir, "RTqPCR.Data.csv"),
                           delim = ";", escape_double = FALSE, locale = locale(decimal_mark = ",",grouping_mark = "."), trim_ws = TRUE)
 
 WB.inj.Data <- readr::read_delim("Data/WB.inj.Data.csv",delim = ";", escape_double = FALSE, locale = locale(decimal_mark = ",",grouping_mark = "."), trim_ws = TRUE)


### PR DESCRIPTION
## Summary
- make data directory configurable in `start.R`
- load NORT/OLT images using repo-relative paths

## Testing
- `apt-get update` *(fails: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68825650dfac8327a088544877aa5c40