### PR TITLE
Fix Install scripts

### DIFF
--- a/Install.R
+++ b/Install.R
@@ -19,5 +19,6 @@ install.packages(c(
   "knitr",
   "docxtools",
   "weights",
-  "readr"
+  "ggthemes",
+  "effectsize"
 ))

--- a/install_missing.R
+++ b/install_missing.R
@@ -2,7 +2,7 @@ req <- c(
   "magick","forcats","cowplot","statsExpressions","ggplot2",
   "ggsignif","ggstatsplot","rstatix","dplyr","readr","ggrepel",
   "ggpubr","rlang","tidyverse","kableExtra","purrr","knitr",
-  "docxtools","weights"
+  "docxtools","weights","ggthemes","effectsize"
 )
 missing <- setdiff(req, rownames(installed.packages()))
 if(length(missing)) {


### PR DESCRIPTION
## Summary
- deduplicate and expand packages in `Install.R`
- mirror updates to `install_missing.R`

## Testing
- `Rscript -e "1+1"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825656fe608327ae7f79c81fb262d1