### PR TITLE
Remove inline ggthemes install

### DIFF
--- a/Install.R
+++ b/Install.R
@@ -19,5 +19,6 @@ install.packages(c(
   "knitr",
   "docxtools",
   "weights",
-  "readr"
+  "readr",
+  "ggthemes"
 ))

--- a/Scripts/BM.2.Graphs.R
+++ b/Scripts/BM.2.Graphs.R
@@ -1,4 +1,3 @@
-install.packages("ggthemes") # Install 
 library(ggthemes) # Load
 
 # Development -------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove `install.packages("ggthemes")` from BM.2.Graphs.R
- add `ggthemes` to the central Install.R script for package management

## Testing
- `Rscript` was unavailable so basic R checks couldn't be run

------
https://chatgpt.com/codex/tasks/task_e_688256660a74832793d108a117a76ce2